### PR TITLE
Installation instructions for MacPorts users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ brew install gdub
 
 [homebrew]: http://brew.sh
 
+## MacPorts
+If you use [MacPorts](https://www.macports.org), you can install gdub like so:
+
+```bash
+sudo port install gdub
+```
+
 ## bpkg
 If you use [bpkg][], you may install like so:
 


### PR DESCRIPTION
I recently contributed a Portfile for gdub to MacPorts, so gdub can now also be installed via MacPorts. I added a small section to the readme to indicate this option.