### PR TITLE
gw: always execute from same dir that gradle or gradlew would (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/gradle/
+/gradlew
+/gradlew.bat
+.gradle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+dist: trusty
+language: java
+install: true
+script:
+  # test once without and with wrapper present
+  - gradle noWrapper
+  - gradle clean test
+  - gradle wrapper
+  - gradle clean test
+

--- a/bin/gw
+++ b/bin/gw
@@ -56,10 +56,7 @@ execute_gradle() {
   local gradle=$(select_gradle "${working_dir}")
   local build_args=( ${BUILD_ARG} "$@" )
 
-  if [[ -n "${build_gradle}" ]]; then
-    # We got a good build file, start gradlew there.
-    cd "$(dirname "${build_gradle}")"
-  else
+  if [[ -z "${build_gradle}" ]]; then
     err "Unable to find a gradle build file named ${GRADLE_BUILDFILE}."
   fi
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+	id 'java'
+}
+
+task wrapper(type: Wrapper) {
+	gradleVersion = '4.3.1'
+}
+
+task noWrapper() {
+	doLast {
+		delete 'gradle'
+		delete 'gradlew'
+		delete 'gradlew.bat'
+	}
+}
+
+task testProjectWithSubproject(type: Exec) {
+	workingDir 'test/project-with-subproject'
+	commandLine './test.sh'
+}
+
+test.dependsOn 'testProjectWithSubproject'

--- a/test/project-with-subproject/build.gradle
+++ b/test/project-with-subproject/build.gradle
@@ -1,0 +1,13 @@
+task speak {
+	doLast {
+		println 'rootProjectSpeak'
+	}
+}
+
+configure(subprojects.findAll {it.name == 'subproject'}) {
+    task speak {
+        doLast {
+            println 'subprojectSpeak'
+        }
+    }
+}

--- a/test/project-with-subproject/settings.gradle
+++ b/test/project-with-subproject/settings.gradle
@@ -1,0 +1,1 @@
+include 'subproject'

--- a/test/project-with-subproject/test.sh
+++ b/test/project-with-subproject/test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+GW=${PWD}/../../bin/gw
+GRADLEW=${PWD}/../../gradlew
+GRADLE="gradle"
+
+if [ -x ${GRADLEW} ]; then
+# gradlew from rootProject should find both speeches
+gradlewSpeakInRootProject=$(${GRADLEW} speak)
+echo $gradlewSpeakInRootProject | grep "rootProjectSpeak" || \
+	{ echo "FAILED: gradlew failed to find rootProjectSpeak running from rootProject";exit 1; }
+echo $gradlewSpeakInRootProject | grep "subprojectSpeak" || \
+	{ echo "FAILED: gradlew failed to find subprojectSpeak running from rootProject";exit 1; }
+fi
+
+# gradle from rootProject should find both speeches
+gradleSpeakInRootProject=$(${GRADLE} speak)
+echo $gradleSpeakInRootProject | grep "rootProjectSpeak" || \
+	{ echo "FAILED: gradlew failed to find rootProjectSpeak running from rootProject";exit 1; }
+echo $gradleSpeakInRootProject | grep "subprojectSpeak" || \
+	{ echo "FAILED: gradlew failed to find subprojectSpeak running from rootProject";exit 1; }
+
+# gw from rootProject should find both speeches
+gwSpeakInRootProject=$(${GW} speak)
+echo $gwSpeakInRootProject | grep "rootProjectSpeak" || \
+	{ echo "FAILED: gw failed to find rootProjectSpeak running from rootProject";exit 1; }
+echo $gwSpeakInRootProject | grep "subprojectSpeak" || \
+	{ echo "FAILED: gw failed to find subprojectSpeak running from rootProject";exit 1; }
+
+# and again from subproject
+cd subproject
+
+if [ -x ${GRADLEW} ]; then
+# gradlew from subproject should find only subproject speeches
+gradlewSpeakInSubproject=$(${GRADLEW} speak)
+echo $gradlewSpeakInSubproject | grep "rootProjectSpeak" && \
+	{ echo "FAILED: gradlew found rootProjectSpeak running from subproject";exit 1; }
+echo $gradlewSpeakInSubproject | grep "subprojectSpeak" || \
+	{ echo "FAILED: gradlew failed to find subprojectSpeak running from subproject";exit 1; }
+fi
+
+# gradle from subproject won't find rootProject speeches
+gradleSpeakInSubproject=$(${GRADLE} speak)
+echo $gradleSpeakInSubproject | grep "rootProjectSpeak" && \
+	{ echo "FAILED: gradle found rootProjectSpeak running from subproject";exit 1; }
+
+# gw from subproject should find only subproject speeches
+gwSpeakInSubproject=$(${GW} speak)
+echo $gwSpeakInSubproject | grep "rootProjectSpeak" && \
+	{ echo "FAILED: gw found rootProjectSpeak running from subproject";exit 1; }
+echo $gwSpeakInSubproject | grep "subprojectSpeak" || \
+	{ echo "FAILED: gw failed to find subprojectSpeak running from subproject";exit 1; }


### PR DESCRIPTION
This PR:

* Commit 1
  * adds a gradle build for `gw` itself, just as a convenient way of running some script-tests.
  * adds a Travis build for running those tests.
  * adds test which run both before and after a gradle-wrapper is installed, testing `gradle` and `gradlew` wrapping behaviour.  The test fails - it is testing that the correct subproject task is executed in a subproject without a `build.gradle`, and checks the behaviour is the same for all four of `gradle`, `gradlew`, `gw`->`gradle`, `gw`->`gradlew`.
* Commit fixes by removing the `cd` to the closest ancestor dir with a `build.gradle`.

In a properly constructed multi-project Gradle project this should make no difference - Gradle doesn't require you to run `-b ../../......../build.gradle` and `gw` should not assume you want to run from the rootProject, because neither `gradle` nor `gradlew` do.