### PR TITLE
docs(link): update bpkg link in README.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ If you use [bpkg][], you may install like so:
 bpkg install dougborg/gdub -g
 ```
 
-[bpkg]: http://www.bpkg.io
+[bpkg]: https://www.bpkg.sh
 
 ## Installing gdub from source
 You will probably want to [install Gradle][] first. While this is not


### PR DESCRIPTION
The bpkg project has moved to https://www.bpkg.sh - http://www.bpkg.io seems to have been hijacked and has spam on the index page.

You can see the bpkg site repo's CNAME file to confirm the move - https://github.com/bpkg/bpkg.github.io/blob/master/CNAME