### PR TITLE
fix: It should not change directory making the root project build run…

### DIFF
--- a/bin/gw
+++ b/bin/gw
@@ -66,7 +66,7 @@ execute_gradle() {
         build_gradle=${build_gradle_kts}
     fi
     # We got a good build file, start gradlew there.
-    cd "$(dirname "${build_gradle}")"
+    # cd "$(dirname "${build_gradle}")" # If you want to run only for current project
   else
     err "Unable to find a gradle build file named ${GRADLE_BUILDFILE} or ${GRADLE_KTS_BUILDFILE}."
   fi


### PR DESCRIPTION
Running the build from the directory your are trying to run the build. how a ../../gradlew behaves. instead of changing directory